### PR TITLE
docs: clarify alphasat outcomes and boolean formulas

### DIFF
--- a/docs/src/many-valued-multi-modal-tableau.md
+++ b/docs/src/many-valued-multi-modal-tableau.md
@@ -31,6 +31,11 @@ newframes(
 Base.show(io::IO, t::T) where {T<:ManyValuedMultiModalTableau}
 ```
 
+```@docs
+alphasat
+booleantofuzzy
+```
+
 Each many-valued multi-modal logic is associated with a specific tableau
 structure subtype of `ManyValuedMultiModalTableau`, and must comprise a
 `judgement`, an `assertion`, a `world`, a `frame`, a `father`, an array of
@@ -44,6 +49,23 @@ of `world` and `frame`, which can be either a `ManyValuedLinearOrder` or an
 
 All structures will be digested by the same algorithms, parameterized on the
 subtype of `ManyValuedMultiModalTableau`.
+
+## Calling `alphasat`
+
+`alphasat` returns one of three values: `true` for a satisfiable branch,
+`false` when all branches are closed, or `nothing` when the timeout or memory
+exit is reached. `nothing` is **undetermined**, not unsatisfiable; callers must
+keep it distinct from `false`.
+
+If a formula contains Boolean negation, transform it before calling
+`alphasat`:
+
+```julia
+formula = booleantofuzzy(formula)
+result = alphasat(MVHSTableau, α, formula, algebra)
+```
+
+`booleantofuzzy` replaces each Boolean `¬φ` with `φ → ⊥`, recursively.
 
 ## A tableau for Many-Valued Linear Temporal Logic with Future and Past
 

--- a/src/many-valued-multi-modal-tableau/alphasat.jl
+++ b/src/many-valued-multi-modal-tableau/alphasat.jl
@@ -108,6 +108,21 @@ function findtableau(
     return false
 end
 
+"""
+    alphasat(metricheaps, choosenode, algebra; timeout=nothing)
+
+Run the many-valued multi-modal tableau search for α-satisfiability.
+
+Returns `true` when the search finds an expanded (satisfiable) branch,
+`false` when all branches are closed, and `nothing` when the search exits
+because `timeout` elapsed or memory use remained too high after a garbage
+collection attempt. `nothing` means **undetermined**, not unsatisfiable; a
+consumer must not conflate it with `false`.
+
+For Boolean formulas, apply [`booleantofuzzy`](@ref) before passing the
+formula to `alphasat`, so Boolean negations are represented as implication
+to bottom.
+"""
 function alphasat(
     metricheaps::Vector{MetricHeap},
     choosenode::F,


### PR DESCRIPTION
## Summary

Addresses the documentation portions of #14:

- Documents that `alphasat` returns `true`, `false`, or `nothing`, and that `nothing` is an undetermined timeout/memory exit—not unsatisfiability.
- Adds a first-caller note and example applying `booleantofuzzy` before `alphasat`.
- Exposes both APIs on the many-valued multi-modal tableau docs page.

I inspected `src/many-valued-multi-modal-tableau/alphasat.jl`, the MVHS tableau implementation, the in-repository READMEs/docs, and the utility implementation. Those sources do not identify a Halpern–Shoham decidable fragment or provide a termination/complexity guarantee, so this PR deliberately does not state one; that item needs an author's answer. Certificate/witness extraction and tableau behavior are also deliberately untouched.

## Verification

- Ran a Julia scratch session confirming `booleantofuzzy(¬p)` produces `p → ⊥` and that the transformed formula can be passed to `alphasat`.
- `julia --project -e 'using Pkg; Pkg.test()'` was started but timed out locally.
- The docs build was attempted with `julia --project=docs docs/make.jl`; it could not load the local `SoleReasoners` package because the docs environment has not installed it.
