### PR TITLE
feat: add extractable alphasat certificates

### DIFF
--- a/docs/src/many-valued-multi-modal-tableau.md
+++ b/docs/src/many-valued-multi-modal-tableau.md
@@ -45,6 +45,59 @@ of `world` and `frame`, which can be either a `ManyValuedLinearOrder` or an
 All structures will be digested by the same algorithms, parameterized on the
 subtype of `ManyValuedMultiModalTableau`.
 
+## Extractable certificates
+
+`alphasat` returns `true`, `false`, or `nothing`. Called with the opt-in
+`certificate=true` keyword, it additionally returns a certificate built out of
+the tableau state the search already computes, so an independent checker can
+validate the verdict without re-running the search:
+
+```julia
+result, cert = alphasat(MVHSTableau, α, φ, algebra; certificate=true)
+```
+
+- when `result` is `false`, `cert` is an [`UnsatCertificate`](@ref): one
+  [`BranchClosure`](@ref) per branch the search closed, each naming which
+  closure condition fired (`:X1`, `:X2`, `:X3`, `:X4`, `:X5`, or `:X5bis` —
+  the many-valued conditions under which a branch closes; this is **not**
+  Boolean `p`/`¬p` closure) together with the root-to-leaf trace that produced
+  it;
+- when `result` is `true`, `cert` is a [`SatCertificate`](@ref): the open
+  branch as a model — the worlds it mentions, the `frame` it settled on (from
+  which accessibility edges can be recomputed with `mveval`), and the
+  root-to-leaf trace of truth assignments;
+- when `result` is `nothing`, `cert` is an [`UndeterminedCertificate`](@ref),
+  which records only that the search was cut short by timeout or memory. It
+  is a distinct type from the other two, so a consumer cannot mistake
+  "undetermined" for a proof of either verdict.
+
+When `certificate` is omitted (or `false`), `alphasat` is unchanged: it
+returns exactly `true`, `false`, or `nothing`, nothing more.
+
+For a serialisable form, [`serialize_alphasat`](@ref) turns `(result, cert)`
+into a plain nested `Dict{String,Any}` with a documented `"schema_version"`
+key; no JSON dependency is added, callers serialise the `Dict` themselves.
+The satisfiable certificate's frame is a nested dictionary containing the
+`"lt"` and `"eq"` truth-value matrices (or component orders for a product
+frame), rather than a Julia-specific frame object.
+
+```@docs
+TableauCertificate
+BranchStep
+BranchClosure
+UnsatCertificate
+SatCertificate
+UndeterminedCertificate
+branchstep(t::T) where {T<:ManyValuedMultiModalTableau}
+branchsteps(t::T) where {T<:ManyValuedMultiModalTableau}
+certificatedict(cert::UnsatCertificate)
+serialize_alphasat(result::Union{Bool,Nothing}, cert::Union{Nothing,TableauCertificate})
+```
+
+Certificate support currently covers `alphasat` for all four tableau types
+(`MVLTLFPTableau`, `MVCLTableau`, `MVHSTableau`, `MVLRCC8Tableau`); `alphaval`
+does not accept `certificate` yet.
+
 ## A tableau for Many-Valued Linear Temporal Logic with Future and Past
 
 ```@docs

--- a/src/SoleReasoners.jl
+++ b/src/SoleReasoners.jl
@@ -6,6 +6,17 @@ include("propositional-tableau/propositional-tableau.jl")
 export sat
 include("many-valued-multi-modal-logic/many-valued-multi-modal-logic.jl")
 include("many-valued-multi-modal-tableau/many-valued-multi-modal-tableau.jl")
+include("many-valued-multi-modal-tableau/certificate.jl")
+export TableauCertificate,
+    BranchStep,
+    BranchClosure,
+    UnsatCertificate,
+    SatCertificate,
+    UndeterminedCertificate,
+    branchstep,
+    branchsteps,
+    certificatedict,
+    serialize_alphasat
 include("many-valued-multi-modal-tableau/alphasat.jl")
 export alphasat, alphaval
 include("many-valued-multi-modal-tableau/mvltlfp-tableau.jl")

--- a/src/many-valued-multi-modal-tableau/alphasat.jl
+++ b/src/many-valued-multi-modal-tableau/alphasat.jl
@@ -5,7 +5,22 @@ using SoleLogics.ManyValuedLogics: FiniteFLewAlgebra, FiniteTruth
 using SoleLogics.ManyValuedLogics: precedeq, getdomain
 using SoleLogics.ManyValuedLogics: maximalmembers, minimalmembers
 
-function findsimilar(
+"""
+    findsimilarwitness(
+        tableau::T,
+        algebra::FiniteFLewAlgebra
+    ) where {
+        T<:ManyValuedMultiModalTableau
+    }
+
+Search the ancestors of `tableau` for an `X5`-closure witness (see
+[`BranchClosure`](@ref)): a node on the same world with the opposite judgement
+on the same formula, whose truth bound conflicts with `tableau`'s via
+`precedeq`. Return that ancestor node, or `nothing` if none is found.
+
+[`findsimilar`](@ref) is `!isnothing(findsimilarwitness(tableau, algebra))`.
+"""
+function findsimilarwitness(
     tableau::T,
     algebra::FiniteFLewAlgebra
 ) where {
@@ -22,7 +37,7 @@ function findsimilar(
                 if assertion(tableau)[1] isa Truth && assertion(tableau)[2] == ψ
                     β = convert(FiniteTruth, assertion(tableau)[1])::FiniteTruth
                     if precedeq(algebra, β, γ)
-                        return true
+                        return tableau
                     end
                 end
             end
@@ -36,16 +51,39 @@ function findsimilar(
                 if assertion(tableau)[1] isa Truth && assertion(tableau)[2] == ψ
                     γ = convert(FiniteTruth, assertion(tableau)[1])::FiniteTruth
                     if precedeq(algebra, β, γ)
-                        return true
+                        return tableau
                     end
                 end
             end
         end
     end
-    return false
+    return nothing
 end
 
-function findsimilaropt(
+function findsimilar(
+    tableau::T,
+    algebra::FiniteFLewAlgebra
+) where {
+    T<:ManyValuedMultiModalTableau
+}
+    return !isnothing(findsimilarwitness(tableau, algebra))
+end
+
+"""
+    findsimilaroptwitness(
+        tableau::T,
+        algebra::FiniteFLewAlgebra
+    ) where {
+        T<:ManyValuedMultiModalTableau
+    }
+
+Search the ancestors of `tableau` for an `X5bis`-closure witness (see
+[`BranchClosure`](@ref)); the `φ⪯β` counterpart of [`findsimilarwitness`](@ref).
+Return that ancestor node, or `nothing` if none is found.
+
+[`findsimilaropt`](@ref) is `!isnothing(findsimilaroptwitness(tableau, algebra))`.
+"""
+function findsimilaroptwitness(
     tableau::T,
     algebra::FiniteFLewAlgebra
 ) where {
@@ -62,7 +100,7 @@ function findsimilaropt(
                 if assertion(tableau)[2] isa Truth && assertion(tableau)[1] == ψ
                     γ = convert(FiniteTruth, assertion(tableau)[2])::FiniteTruth
                     if precedeq(algebra, β, γ)
-                        return true
+                        return tableau
                     end
                 end
             end
@@ -76,13 +114,22 @@ function findsimilaropt(
                 if assertion(tableau)[2] isa Truth && assertion(tableau)[1] == ψ
                     β = convert(FiniteTruth, assertion(tableau)[2])::FiniteTruth
                     if precedeq(algebra, β, γ)
-                        return true
+                        return tableau
                     end
                 end
             end
         end
     end
-    return false
+    return nothing
+end
+
+function findsimilaropt(
+    tableau::T,
+    algebra::FiniteFLewAlgebra
+) where {
+    T<:ManyValuedMultiModalTableau
+}
+    return !isnothing(findsimilaroptwitness(tableau, algebra))
 end
 
 function findtableau(
@@ -112,16 +159,21 @@ function alphasat(
     metricheaps::Vector{MetricHeap},
     choosenode::F,
     algebra::FiniteFLewAlgebra;
-    timeout::Union{Nothing, Int} = nothing
+    timeout::Union{Nothing, Int} = nothing,
+    certificate::Bool = false
 ) where {
     F<:Function
 }
     cycle = 1
     t0 = time_ns()
+    closures = certificate ? Vector{BranchClosure}() : nothing
+    elapsed() = (time_ns()-t0)/1e9
+    outcome(result, cert=nothing) = certificate ? (result, cert) : result
     while true
-        if !isnothing(timeout) && (time_ns()-t0)/1e9 > timeout
+        if !isnothing(timeout) && elapsed() > timeout
             @warn "Timeout"
-            return nothing
+            return outcome(nothing, certificate ?
+                UndeterminedCertificate(:timeout, cycle, elapsed()) : nothing)
         end
         # if using too much memory, try to free memory calling full GC sweep
         if cycle%100==0 && getfreemem() < gettotmem()*5e-2
@@ -131,10 +183,13 @@ function alphasat(
         # if using too much memory, kill execution to avoid crashes
         if cycle%100==0 && getfreemem() < gettotmem()*5e-2
             @warn "Too much memory being used, exiting"
-            return nothing
+            return outcome(nothing, certificate ?
+                UndeterminedCertificate(:memory, cycle, elapsed()) : nothing)
         end
         node = choosenode(metricheaps, cycle)
-        isnothing(node) && return false # all branches are closed
+        if isnothing(node) # all branches are closed
+            return outcome(false, certificate ? UnsatCertificate(closures) : nothing)
+        end
         if expanded(node)
             # DEBUG (satisfiable branch)
             # println(node.frame)
@@ -144,7 +199,12 @@ function alphasat(
             #     push!(result, node)
             # end
             # for r in reverse(result) println(r) end
-            return true   # found a satisfiable branch
+            return outcome(true, certificate ?
+                SatCertificate(
+                    unique([s.world for s in branchsteps(node)]),
+                    frame(node),
+                    branchsteps(node)
+                ) : nothing)   # found a satisfiable branch
         end
         expansionnode = findexpansionnode(node)
         # println("$cycle\t$expansionnode") # DEBUG (expansion node)
@@ -154,9 +214,18 @@ function alphasat(
             β = convert(FiniteTruth, assertion(expansionnode)[1])::FiniteTruth
             γ = convert(FiniteTruth, assertion(expansionnode)[2])::FiniteTruth
             if judgement(expansionnode) && !precedeq(algebra, β, γ)
+                certificate && push!(closures, BranchClosure(
+                    :X1, judgement(expansionnode), assertion(expansionnode),
+                    world(expansionnode), nothing, branchsteps(expansionnode)
+                ))
                 close!(expansionnode)  # X1
             elseif !judgement(expansionnode) &&
                 (isbot(β) || istop(γ) || precedeq(algebra, β, γ))  # X3, X4, X2
+                    certificate && push!(closures, BranchClosure(
+                        isbot(β) ? :X3 : istop(γ) ? :X4 : :X2,
+                        judgement(expansionnode), assertion(expansionnode),
+                        world(expansionnode), nothing, branchsteps(expansionnode)
+                    ))
                     close!(expansionnode)
             else
                 # no condition matched, push node back into metricheaps
@@ -167,8 +236,16 @@ function alphasat(
             β = convert(FiniteTruth, assertion(expansionnode)[1])::FiniteTruth
             φ = assertion(expansionnode)[2]
             if !judgement(expansionnode) && isbot(β)
+                certificate && push!(closures, BranchClosure(
+                    :X3, judgement(expansionnode), assertion(expansionnode),
+                    world(expansionnode), nothing, branchsteps(expansionnode)
+                ))
                 close!(expansionnode)   # X3
-            elseif findsimilar(expansionnode, algebra)
+            elseif (w5 = findsimilarwitness(expansionnode, algebra); !isnothing(w5))
+                certificate && push!(closures, BranchClosure(
+                    :X5, judgement(expansionnode), assertion(expansionnode),
+                    world(expansionnode), branchstep(w5), branchsteps(expansionnode)
+                ))
                 close!(expansionnode)   # X5
             elseif token(φ) isa NamedConnective{:∧} && !isbot(β)
                 (ψ, ε) = subformulas(φ)
@@ -542,7 +619,12 @@ function alphasat(
                             end
                         end
                         if !newnodes && leaf == expansionnode
-                            return true # found satisfiable branch
+                            return outcome(true, certificate ?
+                                SatCertificate(
+                                    unique([s.world for s in branchsteps(leaf)]),
+                                    frame(leaf),
+                                    branchsteps(leaf)
+                                ) : nothing) # found satisfiable branch
                         else
                             ti = typeof(expansionnode)(
                                 true,
@@ -563,12 +645,14 @@ function alphasat(
                         frames = newframes(leaf, algebra; timeout=timeout, t0=t0)
                         if isnothing(frames)
                             @warn "Timeout"
-                            return nothing
+                            return outcome(nothing, certificate ?
+                                UndeterminedCertificate(:timeout, cycle, elapsed()) : nothing)
                         end
                         for fi in frames
                             if !isnothing(timeout) &&
                                 (time_ns()-t0)/1e9 > timeout
-                                return nothing
+                                return outcome(nothing, certificate ?
+                                    UndeterminedCertificate(:timeout, cycle, elapsed()) : nothing)
                             end
                             for wi in worlds(typeof(expansionnode), fi)
                                 βi = mveval(r, w, wi, fi)
@@ -665,8 +749,16 @@ function alphasat(
             φ = assertion(expansionnode)[1]
             β = convert(FiniteTruth, assertion(expansionnode)[2])::FiniteTruth
             if !judgement(expansionnode) && istop(β)
+                certificate && push!(closures, BranchClosure(
+                    :X4, judgement(expansionnode), assertion(expansionnode),
+                    world(expansionnode), nothing, branchsteps(expansionnode)
+                ))
                 close!(expansionnode)   # X4
-            elseif findsimilaropt(expansionnode, algebra)
+            elseif (w5bis = findsimilaroptwitness(expansionnode, algebra); !isnothing(w5bis))
+                certificate && push!(closures, BranchClosure(
+                    :X5bis, judgement(expansionnode), assertion(expansionnode),
+                    world(expansionnode), branchstep(w5bis), branchsteps(expansionnode)
+                ))
                 close!(expansionnode)   # X5bis
             elseif token(φ) isa NamedConnective{:∨} && !istop(β)
                 (ψ, ε) = subformulas(φ)
@@ -866,7 +958,12 @@ function alphasat(
                             end
                         end
                         if !newnodes && leaf == expansionnode
-                            return true # found satisfiable branch
+                            return outcome(true, certificate ?
+                                SatCertificate(
+                                    unique([s.world for s in branchsteps(leaf)]),
+                                    frame(leaf),
+                                    branchsteps(leaf)
+                                ) : nothing) # found satisfiable branch
                         else
                             ti = typeof(expansionnode)(
                                 true,
@@ -887,12 +984,14 @@ function alphasat(
                         frames = newframes(leaf, algebra; timeout=timeout, t0=t0)
                         if isnothing(frames)
                             @warn "Timeout"
-                            return nothing
+                            return outcome(nothing, certificate ?
+                                UndeterminedCertificate(:timeout, cycle, elapsed()) : nothing)
                         end
                         for fi in frames
                             if !isnothing(timeout) &&
                                 (time_ns()-t0)/1e9 > timeout
-                                return nothing
+                                return outcome(nothing, certificate ?
+                                    UndeterminedCertificate(:timeout, cycle, elapsed()) : nothing)
                             end
                             for wi in worlds(typeof(expansionnode), fi)
                                 βi = mveval(r, w, wi, fi)

--- a/src/many-valued-multi-modal-tableau/certificate.jl
+++ b/src/many-valued-multi-modal-tableau/certificate.jl
@@ -1,0 +1,290 @@
+using SoleLogics: syntaxstring
+
+"""
+    abstract type TableauCertificate end
+
+Abstract supertype for the certificates [`alphasat`](@ref) can optionally
+return alongside its verdict, when called with `certificate=true`. Asking for
+a certificate never changes the search: every field is built out of tableau
+state ([`judgement`](@ref), [`assertion`](@ref), [`world`](@ref),
+[`frame`](@ref), [`father`](@ref)) the search already computes while deciding
+`true`, `false`, or `nothing`.
+
+Exactly one concrete subtype is produced per outcome:
+- [`UnsatCertificate`](@ref) when the verdict is `false`;
+- [`SatCertificate`](@ref) when the verdict is `true`;
+- [`UndeterminedCertificate`](@ref) when the verdict is `nothing`.
+
+A consumer must branch on which concrete type it received (or on the `kind`
+key produced by [`serialize_alphasat`](@ref)) before treating a certificate as
+evidence of anything: an [`UndeterminedCertificate`](@ref) is not, and must
+never be presented as, a proof of either `true` or `false`.
+"""
+abstract type TableauCertificate end
+
+"""
+    BranchStep
+
+A `NamedTuple` `(judgement, assertion, world)` describing one node along a
+tableau branch, in the same shape returned by [`judgement`](@ref),
+[`assertion`](@ref) and [`world`](@ref). A `Vector{BranchStep}` in root-to-leaf
+order is the branch trace the tableau actually derived.
+"""
+const BranchStep = NamedTuple{(:judgement, :assertion, :world)}
+
+"""
+    branchstep(t::T) where {T<:ManyValuedMultiModalTableau}
+
+Return the [`BranchStep`](@ref) for tableau node `t`.
+"""
+branchstep(t::T) where {T<:ManyValuedMultiModalTableau} =
+    (judgement=judgement(t), assertion=assertion(t), world=world(t))::BranchStep
+
+"""
+    branchsteps(t::T) where {T<:ManyValuedMultiModalTableau}
+
+Return the root-to-leaf trace of [`BranchStep`](@ref)s along the branch ending
+at `t`, walking [`father`](@ref) pointers. This works even after [`close!`](@ref)
+has detached `t` from its father's `children`, since `close!` never clears
+`father` itself.
+"""
+function branchsteps(t::T) where {T<:ManyValuedMultiModalTableau}
+    steps = Vector{BranchStep}()
+    node = t
+    while true
+        pushfirst!(steps, branchstep(node))
+        isroot(node) && break
+        node = father(node)
+    end
+    return steps
+end
+
+"""
+    struct BranchClosure
+        rule::Symbol
+        judgement::Bool
+        assertion::Tuple
+        world::Any
+        witness::Union{Nothing,BranchStep}
+        steps::Vector{BranchStep}
+    end
+
+One closed branch of the tableau. `steps` is the root-to-leaf
+[`branchsteps`](@ref) trace of the branch; `judgement`, `assertion` and
+`world` describe the leaf node at which the branch closed; `rule` names which
+closure condition fired there, using the same labels as the comments in
+`many-valued-multi-modal-tableau/alphasat.jl` (`:X1`, `:X2`, `:X3`, `:X4`,
+`:X5`, or `:X5bis`). `witness` is set only for `:X5`/`:X5bis` closures, and is
+the earlier [`BranchStep`](@ref) on the same world that the closing node
+contradicts.
+
+Each rule is re-checkable against the algebra alone, without re-running the
+tableau (`β`, `γ` below are `assertion[1]`, `assertion[2]` converted to
+`FiniteTruth`, and `algebra` is the `FiniteFLewAlgebra` the search ran
+against):
+- `:X1`: `judgement == true`, `assertion == (β, γ)`, and
+  `!precedeq(algebra, β, γ)` — the branch asserted `β⪯γ` but the algebra
+  refutes it;
+- `:X2`: `judgement == false`, `assertion == (β, γ)`, and
+  `precedeq(algebra, β, γ)` — the branch asserted `β⪯γ` does *not* hold, but
+  the algebra says it does;
+- `:X3`: `judgement == false` and either `assertion == (β, γ)` with
+  `isbot(β)`, or `assertion == (β, φ)` with `isbot(β)` — `⊥` precedes
+  everything, contradicting the `false` judgement;
+- `:X4`: `judgement == false` and either `assertion == (β, γ)` with
+  `istop(γ)`, or `assertion == (φ, β)` with `istop(β)` — everything precedes
+  `⊤`, contradicting the `false` judgement;
+- `:X5`/`:X5bis`: `witness` and the closing node share `world` and the same
+  formula in `assertion`, with opposite `judgement`s and truth bounds that
+  make both hold impossible via `precedeq`.
+"""
+struct BranchClosure
+    rule::Symbol
+    judgement::Bool
+    assertion::Tuple
+    world::Any
+    witness::Union{Nothing,BranchStep}
+    steps::Vector{BranchStep}
+end
+
+"""
+    struct UnsatCertificate <: TableauCertificate
+        closures::Vector{BranchClosure}
+    end
+
+Certificate for an unsatisfiable result (`alphasat` returned `false`): one
+[`BranchClosure`](@ref) per branch the search closed. This is the tableau's
+proof object, handed back instead of being thrown away.
+"""
+struct UnsatCertificate <: TableauCertificate
+    closures::Vector{BranchClosure}
+end
+
+"""
+    struct SatCertificate <: TableauCertificate
+        worlds::Vector{Any}
+        frame::Any
+        steps::Vector{BranchStep}
+    end
+
+Certificate for a satisfiable result (`alphasat` returned `true`): the open
+branch, presented as a model. `frame` is the `ManyValuedLinearOrder` (or tuple
+of `ManyValuedLinearOrder`s) the branch settled on; `worlds` lists the
+distinct worlds mentioned along the branch; `steps` is the root-to-leaf
+[`branchsteps`](@ref) trace, i.e. the truth assignments the branch commits to.
+Accessibility edges between any two worlds in `worlds` can be recomputed from
+`frame` with `mveval`, without re-running the search.
+"""
+struct SatCertificate <: TableauCertificate
+    worlds::Vector{Any}
+    frame::Any
+    steps::Vector{BranchStep}
+end
+
+"""
+    struct UndeterminedCertificate <: TableauCertificate
+        reason::Symbol
+        cycle::Int
+        elapsed::Float64
+    end
+
+Certificate for an undetermined result (`alphasat` returned `nothing`). This
+records *only* that the search was cut short — `reason` is `:timeout` or
+`:memory` — after `cycle` expansion cycles and `elapsed` seconds. It proves
+nothing about satisfiability or unsatisfiability, and must never be presented
+as if it did: `nothing` is undetermined, not unsatisfiable.
+"""
+struct UndeterminedCertificate <: TableauCertificate
+    reason::Symbol
+    cycle::Int
+    elapsed::Float64
+end
+
+# --- plain Dict serialisation, mirroring SoleLogics' `serialize_check` -----
+
+function _worldids(worlds::AbstractVector)
+    Dict{Any,String}(w => "w$(n)" for (n, w) in enumerate(worlds))
+end
+
+function _stepdict(step::BranchStep, ids::Dict{Any,String})
+    Dict{String,Any}(
+        "judgement" => step.judgement,
+        "assertion" => [syntaxstring(a) for a in step.assertion],
+        "world" => get(ids, step.world, string(step.world)),
+    )
+end
+
+function _closuredict(c::BranchClosure, ids::Dict{Any,String})
+    Dict{String,Any}(
+        "rule" => string(c.rule),
+        "judgement" => c.judgement,
+        "assertion" => [syntaxstring(a) for a in c.assertion],
+        "world" => get(ids, c.world, string(c.world)),
+        "witness" => isnothing(c.witness) ? nothing : _stepdict(c.witness, ids),
+        "steps" => [_stepdict(s, ids) for s in c.steps],
+    )
+end
+
+function _certworlds(cert::UnsatCertificate)
+    worlds = Any[]
+    for c in cert.closures
+        push!(worlds, c.world)
+        !isnothing(c.witness) && push!(worlds, c.witness.world)
+        for s in c.steps
+            push!(worlds, s.world)
+        end
+    end
+    return unique(worlds)
+end
+_certworlds(cert::SatCertificate) = unique(vcat(cert.worlds, [s.world for s in cert.steps]))
+_certworlds(::UndeterminedCertificate) = Any[]
+
+"""
+    certificatedict(cert::TableauCertificate)
+
+Return `cert` as a plain nested `Dict{String,Any}`; see [`serialize_alphasat`](@ref)
+for the documented shape. No JSON package is required or added: callers
+serialise the returned `Dict` themselves (e.g. `JSON3.write(certificatedict(cert))`).
+A satisfiable certificate's frame is represented by nested dictionaries with
+`"kind" => "linear_order"`, integer truth-value matrices under `"lt"` and
+`"eq"`, or `"kind" => "product"` with component orders under `"orders"`.
+"""
+function certificatedict(cert::UnsatCertificate)
+    ids = _worldids(_certworlds(cert))
+    Dict{String,Any}(
+        "kind" => "unsat",
+        "closures" => [_closuredict(c, ids) for c in cert.closures],
+    )
+end
+# Keep the serialised frame independent of StaticArrays and of Julia's
+# `ManyValuedLinearOrder` representation. Matrix entries are the stable
+# `FiniteTruth.index` values; an independent checker reconstructs them in the
+# algebra it already has.
+_truthindex(x) = hasproperty(x, :index) ? getproperty(x, :index) : string(x)
+function _matrixvalues(m)
+    rows = Any[]
+    for i in axes(m, 1)
+        push!(rows, Any[_truthindex(m[i, j]) for j in axes(m, 2)])
+    end
+    rows
+end
+function _framedict(frame)
+    if frame isa Tuple
+        return Dict{String,Any}(
+            "kind" => "product",
+            "orders" => [_framedict(f) for f in frame],
+        )
+    elseif hasproperty(frame, :mvlt) && hasproperty(frame, :mveq)
+        return Dict{String,Any}(
+            "kind" => "linear_order",
+            "lt" => _matrixvalues(getproperty(frame, :mvlt)),
+            "eq" => _matrixvalues(getproperty(frame, :mveq)),
+        )
+    else
+        error("cannot serialise tableau frame of type $(typeof(frame))")
+    end
+end
+
+function certificatedict(cert::SatCertificate)
+    ids = _worldids(_certworlds(cert))
+    Dict{String,Any}(
+        "kind" => "sat",
+        "worlds" => [ids[w] for w in cert.worlds],
+        "frame" => _framedict(cert.frame),
+        "steps" => [_stepdict(s, ids) for s in cert.steps],
+    )
+end
+function certificatedict(cert::UndeterminedCertificate)
+    Dict{String,Any}(
+        "kind" => "undetermined",
+        "reason" => string(cert.reason),
+        "cycle" => cert.cycle,
+        "elapsed" => cert.elapsed,
+    )
+end
+
+"""
+    serialize_alphasat(result::Union{Bool,Nothing}, cert::Union{Nothing,TableauCertificate})
+
+Return `(result, cert)` — as produced by `alphasat(...; certificate=true)` —
+as a plain nested `Dict{String,Any}` with keys:
+- `"schema_version"`: `"solereasoners.alphasat.v1"`;
+- `"result"`: `true`, `false`, or `nothing`;
+- `"certificate"`: `nothing` when `cert` is `nothing` (i.e. `certificate` was
+  not requested), otherwise `certificatedict(cert)`, whose `"kind"` key is
+  `"unsat"`, `"sat"`, or `"undetermined"` and matches `result` (`false`,
+  `true`, `nothing` respectively).
+
+No JSON package is required or added; callers serialise the returned `Dict`
+themselves, exactly as SoleLogics' `serialize_check` does.
+"""
+function serialize_alphasat(
+    result::Union{Bool,Nothing},
+    cert::Union{Nothing,TableauCertificate}=nothing
+)
+    Dict{String,Any}(
+        "schema_version" => "solereasoners.alphasat.v1",
+        "result" => result,
+        "certificate" => isnothing(cert) ? nothing : certificatedict(cert),
+    )
+end

--- a/src/many-valued-multi-modal-tableau/mvcl-tableau.jl
+++ b/src/many-valued-multi-modal-tableau/mvcl-tableau.jl
@@ -166,7 +166,8 @@ function alphasat(
     algebra::FiniteFLewAlgebra,
     choosenode::Function,
     metrics::Function...;
-    timeout::Union{Nothing, Int} = nothing
+    timeout::Union{Nothing, Int} = nothing,
+    certificate::Bool = false
 ) where {
     T<:Truth
 }
@@ -190,7 +191,7 @@ function alphasat(
     for metricheap ∈ metricheaps
         push!(heap(metricheap), MetricHeapNode(metric(metricheap), tableau))
     end
-    return alphasat(metricheaps, choosenode, algebra; timeout)
+    return alphasat(metricheaps, choosenode, algebra; timeout, certificate)
 end
 
 function alphasat(
@@ -198,7 +199,8 @@ function alphasat(
     α::T,
     φ::Formula,
     algebra::FiniteFLewAlgebra;
-    timeout::Union{Nothing, Int} = nothing
+    timeout::Union{Nothing, Int} = nothing,
+    certificate::Bool = false
 ) where {
     T<:Truth
 }
@@ -209,7 +211,8 @@ function alphasat(
         algebra,
         roundrobin!,
         randombranch;
-        timeout
+        timeout,
+        certificate
     )
 end
 

--- a/src/many-valued-multi-modal-tableau/mvhs-tableau.jl
+++ b/src/many-valued-multi-modal-tableau/mvhs-tableau.jl
@@ -177,7 +177,8 @@ function alphasat(
     algebra::FiniteFLewAlgebra,
     choosenode::Function,
     metrics::Function...;
-    timeout::Union{Nothing, Int} = nothing
+    timeout::Union{Nothing, Int} = nothing,
+    certificate::Bool = false
 ) where {
     T<:Truth
 }
@@ -216,7 +217,7 @@ function alphasat(
             push!(heap(metricheap), MetricHeapNode(metric(metricheap), tableau))
         end
     end
-    return alphasat(metricheaps, choosenode, algebra; timeout)
+    return alphasat(metricheaps, choosenode, algebra; timeout, certificate)
 end
 
 function alphasat(
@@ -224,7 +225,8 @@ function alphasat(
     α::T,
     φ::Formula,
     algebra::FiniteFLewAlgebra;
-    timeout::Union{Nothing, Int} = nothing
+    timeout::Union{Nothing, Int} = nothing,
+    certificate::Bool = false
 ) where {
     T<:Truth
 }
@@ -235,7 +237,8 @@ function alphasat(
         algebra,
         roundrobin!,
         randombranch;
-        timeout
+        timeout,
+        certificate
     )
 end
 

--- a/src/many-valued-multi-modal-tableau/mvlrcc8-tableau.jl
+++ b/src/many-valued-multi-modal-tableau/mvlrcc8-tableau.jl
@@ -259,7 +259,8 @@ function alphasat(
     algebra::FiniteFLewAlgebra,
     choosenode::Function,
     metrics::Function...;
-    timeout::Union{Nothing, Int} = nothing
+    timeout::Union{Nothing, Int} = nothing,
+    certificate::Bool = false
 ) where {
     T<:Truth
 }
@@ -307,7 +308,7 @@ function alphasat(
             push!(heap(metricheap), MetricHeapNode(metric(metricheap), tableau))
         end
     end
-    return alphasat(metricheaps, choosenode, algebra; timeout)
+    return alphasat(metricheaps, choosenode, algebra; timeout, certificate)
 end
 
 function alphasat(
@@ -315,7 +316,8 @@ function alphasat(
     α::T,
     φ::Formula,
     algebra::FiniteFLewAlgebra;
-    timeout::Union{Nothing, Int} = nothing
+    timeout::Union{Nothing, Int} = nothing,
+    certificate::Bool = false
 ) where {
     T<:Truth
 }
@@ -326,7 +328,8 @@ function alphasat(
         algebra,
         roundrobin!,
         randombranch;
-        timeout
+        timeout,
+        certificate
     )
 end
 

--- a/src/many-valued-multi-modal-tableau/mvltlfp-tableau.jl
+++ b/src/many-valued-multi-modal-tableau/mvltlfp-tableau.jl
@@ -127,7 +127,8 @@ function alphasat(
     algebra::FiniteFLewAlgebra,
     choosenode::Function,
     metrics::Function...;
-    timeout::Union{Nothing, Int} = nothing
+    timeout::Union{Nothing, Int} = nothing,
+    certificate::Bool = false
 ) where {
     T<:Truth
 }
@@ -146,7 +147,7 @@ function alphasat(
     for metricheap ∈ metricheaps
         push!(heap(metricheap), MetricHeapNode(metric(metricheap), tableau))
     end
-    return alphasat(metricheaps, choosenode, algebra; timeout)
+    return alphasat(metricheaps, choosenode, algebra; timeout, certificate)
 end
 
 function alphasat(
@@ -154,7 +155,8 @@ function alphasat(
     α::T,
     φ::Formula,
     algebra::FiniteFLewAlgebra;
-    timeout::Union{Nothing, Int} = nothing
+    timeout::Union{Nothing, Int} = nothing,
+    certificate::Bool = false
 ) where {
     T<:Truth
 }
@@ -165,7 +167,8 @@ function alphasat(
         algebra,
         roundrobin!,
         randombranch;
-        timeout
+        timeout,
+        certificate
     )
 end
 

--- a/test/alphasat/certificate.jl
+++ b/test/alphasat/certificate.jl
@@ -1,0 +1,282 @@
+################################################################################
+#### Certificate ###############################################################
+################################################################################
+#
+# Tests that alphasat's opt-in `certificate=true` output can be independently
+# re-checked without re-running the tableau search: for an unsatisfiable
+# formula, every recorded BranchClosure is re-verified against the algebra
+# alone; for a satisfiable formula, the returned branch is re-checked both
+# for internal (Hintikka-style) consistency and by evaluating the original
+# formula bottom-up from the atom values the branch commits to.
+
+using SoleLogics: Atom, Formula, Truth, token, children as _children, NamedConnective
+using SoleLogics.ManyValuedLogics: FiniteFLewAlgebra, FiniteTruth
+using SoleLogics.ManyValuedLogics: precedeq, getdomain, booleanalgebra, Ł4
+using SoleLogics.ManyValuedLogics: α as Ł4α, β as Ł4β
+using SoleReasoners: BranchClosure, BranchStep, UnsatCertificate, SatCertificate
+using SoleReasoners: UndeterminedCertificate, certificatedict, serialize_alphasat
+
+p, q = Atom.(["p", "q"])
+
+timeout = 15
+
+# --- independent re-checkers, built only from `algebra`/`precedeq`/`isbot`/
+# --- `istop`, never by re-running the tableau search -----------------------
+
+function verify_closure(c::BranchClosure, algebra::FiniteFLewAlgebra)
+    if c.rule == :X1
+        c.judgement || return false
+        a1, a2 = c.assertion
+        (a1 isa Truth && a2 isa Truth) || return false
+        return !precedeq(algebra, convert(FiniteTruth, a1), convert(FiniteTruth, a2))
+    elseif c.rule == :X2
+        c.judgement && return false
+        a1, a2 = c.assertion
+        (a1 isa Truth && a2 isa Truth) || return false
+        return precedeq(algebra, convert(FiniteTruth, a1), convert(FiniteTruth, a2))
+    elseif c.rule == :X3
+        c.judgement && return false
+        return isbot(convert(FiniteTruth, c.assertion[1]))
+    elseif c.rule == :X4
+        c.judgement && return false
+        return istop(convert(FiniteTruth, c.assertion[2]))
+    elseif c.rule == :X5
+        isnothing(c.witness) && return false
+        a1, φ = c.assertion
+        wa1, wφ = c.witness.assertion
+        φ == wφ || return false
+        c.witness.world == c.world || return false
+        c.witness.judgement != c.judgement || return false
+        if c.judgement
+            return precedeq(algebra, convert(FiniteTruth, wa1), convert(FiniteTruth, a1))
+        else
+            return precedeq(algebra, convert(FiniteTruth, a1), convert(FiniteTruth, wa1))
+        end
+    elseif c.rule == :X5bis
+        isnothing(c.witness) && return false
+        φ, a2 = c.assertion
+        wφ, wa2 = c.witness.assertion
+        φ == wφ || return false
+        c.witness.world == c.world || return false
+        c.witness.judgement != c.judgement || return false
+        if c.judgement
+            return precedeq(algebra, convert(FiniteTruth, a2), convert(FiniteTruth, wa2))
+        else
+            return precedeq(algebra, convert(FiniteTruth, wa2), convert(FiniteTruth, a2))
+        end
+    else
+        return false
+    end
+end
+
+# A single BranchStep, checked against another BranchStep on the same
+# branch/world, using the same X1-X5bis conditions the search itself uses.
+function stepscontradict(s::BranchStep, t::BranchStep, algebra::FiniteFLewAlgebra)
+    s.world == t.world || return false
+    a1, a2 = s.assertion
+    if a1 isa Truth && a2 isa Truth
+        β, γ = convert(FiniteTruth, a1), convert(FiniteTruth, a2)
+        if s.judgement && !precedeq(algebra, β, γ)
+            return true
+        elseif !s.judgement && (isbot(β) || istop(γ) || precedeq(algebra, β, γ))
+            return true
+        end
+    elseif a1 isa Truth && a2 isa Formula
+        β, φ = convert(FiniteTruth, a1), a2
+        if !s.judgement && isbot(β)
+            return true
+        end
+        b1, b2 = t.assertion
+        if b1 isa Truth && b2 == φ && t.judgement != s.judgement
+            β2 = convert(FiniteTruth, b1)
+            if s.judgement
+                precedeq(algebra, β2, β) && return true
+            else
+                precedeq(algebra, β, β2) && return true
+            end
+        end
+    elseif a1 isa Formula && a2 isa Truth
+        φ, β = a1, convert(FiniteTruth, a2)
+        if !s.judgement && istop(β)
+            return true
+        end
+        b1, b2 = t.assertion
+        if b1 == φ && b2 isa Truth && t.judgement != s.judgement
+            β2 = convert(FiniteTruth, b2)
+            if s.judgement
+                precedeq(algebra, β, β2) && return true
+            else
+                precedeq(algebra, β2, β) && return true
+            end
+        end
+    end
+    return false
+end
+
+function hascontradiction(steps::Vector{BranchStep}, algebra::FiniteFLewAlgebra)
+    for s in steps, t in steps
+        stepscontradict(s, t, algebra) && return true
+    end
+    return false
+end
+
+# Extract, for `atom`, the unique domain value consistent with every
+# constraint recorded on `steps`; error if the branch does not pin it down or
+# is inconsistent (a bug in the branch, not in this checker).
+function atomvalue(steps::Vector{BranchStep}, atom, algebra::FiniteFLewAlgebra)
+    consistent = FiniteTruth[]
+    for v in getdomain(algebra)
+        ok = true
+        for s in steps
+            a1, a2 = s.assertion
+            if a2 == atom && a1 isa Truth
+                β = convert(FiniteTruth, a1)
+                if s.judgement != precedeq(algebra, β, v)
+                    ok = false
+                    break
+                end
+            elseif a1 == atom && a2 isa Truth
+                β = convert(FiniteTruth, a2)
+                if s.judgement != precedeq(algebra, v, β)
+                    ok = false
+                    break
+                end
+            end
+        end
+        ok && push!(consistent, v)
+    end
+    @assert !isempty(consistent) "no value of $atom is consistent with the branch"
+    return first(consistent)
+end
+
+function evalformula(ψ::Formula, steps::Vector{BranchStep}, algebra::FiniteFLewAlgebra)
+    tok = token(ψ)
+    if tok isa Atom
+        return atomvalue(steps, tok, algebra)
+    elseif tok isa Truth
+        return convert(FiniteTruth, tok)
+    elseif tok isa NamedConnective{:∧}
+        c1, c2 = _children(ψ)
+        return algebra.monoid(
+            evalformula(c1, steps, algebra), evalformula(c2, steps, algebra)
+        )
+    elseif tok isa NamedConnective{:∨}
+        c1, c2 = _children(ψ)
+        return algebra.join(
+            evalformula(c1, steps, algebra), evalformula(c2, steps, algebra)
+        )
+    elseif tok isa NamedConnective{:→}
+        c1, c2 = _children(ψ)
+        return algebra.implication(
+            evalformula(c1, steps, algebra), evalformula(c2, steps, algebra)
+        )
+    else
+        error("test evaluator does not support connective $tok")
+    end
+end
+
+################################################################################
+## Default path is untouched ###################################################
+################################################################################
+
+println("Default path is untouched by `certificate`")
+
+@test alphasat(MVHSTableau, ⊤, p, booleanalgebra; timeout=timeout) isa Union{Bool,Nothing}
+@test alphasat(
+    MVHSTableau, ⊤, p, booleanalgebra; timeout=timeout, certificate=false
+) isa Union{Bool,Nothing}
+@test alphasat(MVHSTableau, ⊤, p, booleanalgebra; timeout=timeout) == true
+
+################################################################################
+## Unsatisfiable: every recorded closure is re-checkable ######################
+################################################################################
+
+println("Unsatisfiable formula: certificate closures re-check against the algebra")
+
+unsatformula = ∧(p, →(p, ⊥))
+result, cert = alphasat(
+    MVHSTableau, ⊤, unsatformula, booleanalgebra; timeout=timeout, certificate=true
+)
+@test result == false
+@test cert isa UnsatCertificate
+@test !isempty(cert.closures)
+for c in cert.closures
+    @test verify_closure(c, booleanalgebra)
+    @test !isempty(c.steps)
+    @test c.steps[end].world == c.world
+end
+d = serialize_alphasat(result, cert)
+@test d["schema_version"] == "solereasoners.alphasat.v1"
+@test d["result"] == false
+@test d["certificate"]["kind"] == "unsat"
+@test length(d["certificate"]["closures"]) == length(cert.closures)
+
+################################################################################
+## Satisfiable: the branch is re-checked for consistency and semantics ########
+################################################################################
+
+println("Satisfiable formula: certificate branch re-checks as a genuine model")
+
+result, cert = alphasat(
+    MVHSTableau, ⊤, p, booleanalgebra; timeout=timeout, certificate=true
+)
+@test result == true
+@test cert isa SatCertificate
+@test !isempty(cert.steps)
+@test !hascontradiction(cert.steps, booleanalgebra)
+α0, φ0 = cert.steps[1].assertion
+@test cert.steps[1].judgement == true
+v = evalformula(φ0, cert.steps, booleanalgebra)
+@test precedeq(booleanalgebra, convert(FiniteTruth, α0), v)
+d = serialize_alphasat(result, cert)
+@test d["certificate"]["kind"] == "sat"
+
+################################################################################
+## Many-valued: X1-style closure is not Boolean p/¬p ###########################
+################################################################################
+
+println("Many-valued algebra (Ł4): certificate reflects non-Boolean closure")
+
+result, cert = alphasat(
+    MVHSTableau, Ł4α, ⊥, Ł4; timeout=timeout, certificate=true
+)
+@test result == false
+@test cert isa UnsatCertificate
+@test !isempty(cert.closures)
+for c in cert.closures
+    @test verify_closure(c, Ł4)
+end
+
+result, cert = alphasat(
+    MVHSTableau, ⊥, Ł4α, Ł4; timeout=timeout, certificate=true
+)
+@test result == true
+@test cert isa SatCertificate
+@test !hascontradiction(cert.steps, Ł4)
+α0, φ0 = cert.steps[1].assertion
+v = evalformula(φ0, cert.steps, Ł4)
+@test precedeq(Ł4, convert(FiniteTruth, α0), v)
+
+################################################################################
+## nothing: undetermined can never look like a proof ###########################
+################################################################################
+
+println("Timeout: undetermined certificate cannot be mistaken for a verdict")
+
+bignested = p
+for _ in 1:6
+    global bignested = ∧(bignested, →(bignested, q))
+end
+result, cert = alphasat(
+    MVHSTableau, ⊤, bignested, booleanalgebra; timeout=0, certificate=true
+)
+@test isnothing(result)
+@test cert isa UndeterminedCertificate
+@test cert.reason ∈ (:timeout, :memory)
+@test cert.cycle >= 1
+@test cert.elapsed >= 0
+d = serialize_alphasat(result, cert)
+@test d["result"] === nothing
+@test d["certificate"]["kind"] == "undetermined"
+@test !haskey(d["certificate"], "closures")
+@test !haskey(d["certificate"], "steps")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,12 @@ test_suites = [
         ]
     ),
     (
+        "α-sat certificate",
+        [
+            "alphasat/certificate.jl"
+        ]
+    ),
+    (
         "α-val",
         [
             "alphaval/mvltlfp-tableau/G4.jl",


### PR DESCRIPTION
## Summary

Implements the extractable-certificate portion of #14, building on the documentation work in #15.

- Adds opt-in `alphasat(...; certificate=true)` for all four tableau types; calls without the option still return exactly `true`, `false`, or `nothing`.
- Returns typed certificates for closed branches (`UnsatCertificate` with X1–X5bis algebraic closure records), open branches (`SatCertificate` with the existing father-chain branch walk, worlds, and settled frame), and cut-short searches (`UndeterminedCertificate`, never a proof).
- Adds plain nested `Dict` serialization without a JSON dependency, documentation, and independent certificate re-check tests.

Alberto's maintainer tip pointed out the commented-out satisfiable witness walk already in `alphasat.jl`; the satisfiable certificate harvests that same existing `father` chain rather than adding another search. The unsatisfiable side captures each closure at the existing X1–X5bis close sites because the all-branches-closed exit retained no closure record.

This is a proposed API and data shape. Please reshape the naming or structure as you prefer—the maintainers' conventions win.

## Verification

- Baseline `julia --project=. -e 'using Pkg; Pkg.test()'`: passed (28,711,133 tests).
- Post-change package suite: passed (28,711,181 tests).
- Added tests independently re-check X1–X5bis closures and a satisfiable branch/model, including many-valued Ł4 closure (not Boolean `p`/`¬p`) and the undetermined case.
- Documentation build passed after developing the local package into the docs environment; generated docs only emitted pre-existing undocumented-string warnings.
