### PR TITLE
docs: add runnable API guide and reasoning playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,137 @@
 
 ## Installation
 
-To install SoleReasoners.jl, use the Julia package manager:
 ```julia
 using Pkg
 Pkg.add("SoleReasoners")
 ```
 
-## Feature Summary
+## Quick start: propositional SAT
 
-SoleReasoners.jl provides a [SAT solver](https://en.wikipedia.org/wiki/SAT_solver) and an [automated theorem prover](https://en.wikipedia.org/wiki/Automated_theorem_proving) up to Many-Valued Multi-Modal Logic based on the [method of analytic tableaux](https://en.wikipedia.org/wiki/Method_of_analytic_tableaux). 
+Formulas are built with SoleLogics. `sat` returns a `Bool` for the classical
+(propositional) tableau:
+
+```julia
+using SoleReasoners
+using SoleLogics: Atom, ∧, ∨, ¬
+
+p, q = Atom.(["p", "q"])
+sat(∧(p, ¬p))                 # false
+sat(∨(p, q))                  # true
+
+# Choose a policy and one or more branch metrics explicitly.
+sat(∨(p, q), roundrobin!, distancefromroot)
+```
+
+A formula can also be read from text with `SoleLogics.parseformula`, or from a
+DIMACS CNF file with `dimacstosole`:
+
+```julia
+using SoleLogics: parseformula
+sat(parseformula("(p ∨ q) ∧ ¬p"))
+# sat(dimacstosole("problem.cnf"))
+```
+
+## Many-valued reasoning
+
+`alphasat(TableauType, α, φ, algebra)` asks whether `φ` is satisfiable at
+threshold `α`; `alphaval` asks whether it is valid at that threshold. The
+short form uses `roundrobin!` and `randombranch`. In the Boolean algebra use
+`⊤` as the threshold. Other finite algebras (such as `G3`) provide their own
+truth values, including `α`.
+
+```julia
+using SoleReasoners
+using SoleLogics: Atom, ∧, →, ⊤
+using SoleLogics.ManyValuedLogics: booleanalgebra, G3, α
+
+p, q = Atom.(["p", "q"])
+alphasat(MVLTLFPTableau, ⊤, ∧(p, q), booleanalgebra) # true
+alphaval(MVLTLFPTableau, α, →(p, p), G3)             # true
+```
+
+The four exported tableau types select the supported logic:
+
+| Tableau type | Logic | Initial world/frame built by the solver |
+| --- | --- | --- |
+| `MVLTLFPTableau` | Many-Valued Linear Temporal Logic with future and past | a point and a linear order |
+| `MVCLTableau` | Many-Valued Compass Logic | a 2-D point and two linear orders |
+| `MVHSTableau` | Many-Valued Halpern--Shoham interval logic | an interval and a linear order |
+| `MVLRCC8Tableau` | Many-Valued Lutz--Wolter RCC8 rectangular logic | a rectangle and two linear orders |
+
+For example, the same Boolean formula can be checked with every tableau
+implementation (each call was run against the package):
+
+```julia
+for tableau in (MVLTLFPTableau, MVCLTableau, MVHSTableau, MVLRCC8Tableau)
+    @show tableau alphasat(tableau, ⊤, ∧(p, q), booleanalgebra)
+end
+```
+
+Modal and temporal operators come from SoleLogics. For example, this is a
+future-box formula for the LTL-with-future-and-past tableau:
+
+```julia
+using SoleLogics: box, LTLFP_F
+alphasat(MVLTLFPTableau, ⊤, box(LTLFP_F)(p), booleanalgebra; timeout=10)
+```
+
+See [`examples/playground.jl`](examples/playground.jl) for a complete script
+that can be run with `julia --project=. examples/playground.jl`.
+
+## How to choose a tableau policy
+
+A policy receives the metric heaps and the current expansion cycle. The
+recommended starvation-free policy is `roundrobin!`; `mostvoted!` selects the
+candidate occurring at the head of most heaps. A metric receives a tableau
+node and returns an integer. Built-in metrics are `randombranch`,
+`distancefromroot`, `inversedistancefromroot`, and `formulaheight` (the last is
+for many-valued tableaux). Pass a deterministic metric when reproducibility
+matters, for example:
+
+```julia
+using SoleReasoners: roundrobin!, distancefromroot
+alphasat(MVLTLFPTableau, ⊤, ∧(p, q), booleanalgebra,
+         roundrobin!, distancefromroot; timeout=10)
+```
+
+## Exported API
+
+These are the names exported by `SoleReasoners` (the list is derived from
+`src/SoleReasoners.jl`):
+
+- **Decision procedures:** `sat` (propositional satisfiability), `alphasat`
+  (many-valued α-satisfiability), and `alphaval` (many-valued α-validity).
+- **Tableau constructors:** `MVLTLFPTableau`, `MVCLTableau`, `MVHSTableau`, and
+  `MVLRCC8Tableau`.
+- **Expansion policies:** `roundrobin!` and `mostvoted!`.
+- **Metrics:** `randombranch`, `distancefromroot`, `inversedistancefromroot`,
+  and `formulaheight`.
+- **Utilities:** `booleantofuzzy` (replace Boolean negation by implication to
+  bottom) and `dimacstosole` (read a DIMACS CNF path as a SoleLogics formula).
+
+Formula constructors, atoms, truth values, finite algebras, and modal
+relations are supplied by [SoleLogics.jl](https://github.com/aclai-lab/SoleLogics.jl)
+and [SoleLogics.ManyValuedLogics]. They are intentionally not repeated as
+SoleReasoners exports.
+
+## Known limitations and result meanings
+
+- `sat` is the propositional tableau implementation. Its expansion rules are
+  for atoms, Boolean truth constants, `¬`, `∨`, `∧`, and `→`; it is not the
+  many-valued/modal decision procedure.
+- The many-valued procedures operate on the four tableau families above and
+  finite `FiniteFLewAlgebra` instances. A timeout is available as
+  `timeout=<seconds>`.
+- `alphasat` and `alphaval` return `Bool` when the search finishes. They return
+  `nothing` on timeout or when the implementation's memory guard aborts the
+  search. Do not interpret `nothing` as unsatisfiable or invalid.
+- The source defines the tableau rules and finite-frame generation, but does
+  not state a general decidable fragment or a completeness/termination bound
+  for every supported modal logic. That limit is therefore intentionally
+  unstated here rather than guessed; use a timeout for exploratory searches.
+- The current procedures return only the decision result. They do not promise
+  a model, proof, or certificate object.
 
 ## About
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,7 @@ makedocs(;
         "Metric Heap" => "metric-heap.md",
         "Many-Valued Multi-Modal Logic" => "many-valued-multi-modal-logic.md",
         "Many-Valued Multi-Modal Tableau" => "many-valued-multi-modal-tableau.md",
-        # "Examples" => "examples.md",
+        "Examples" => "examples.md",
         ],
     # NOTE: warning
     warnonly = :true,

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -6,5 +6,95 @@ CurrentModule = SoleReasoners
 Pages = ["examples.md"]
 ```
 
-# [Examples](@id man-core)
+# [Examples](@id examples)
 
+This page is a runnable playbook. The complete version is
+[`examples/playground.jl`](https://github.com/aclai-lab/SoleReasoners.jl/blob/main/examples/playground.jl).
+Run it from a checkout with `julia --project=. examples/playground.jl`.
+
+## 1. Build formulas and run propositional SAT
+
+```julia
+using SoleReasoners
+using SoleLogics: Atom, ∧, ∨, ¬
+
+p, q = Atom.(["p", "q"])
+sat(∧(p, ¬p))
+sat(∨(p, q), roundrobin!, distancefromroot)
+```
+
+The first call is `false`; the second is `true`. `sat` is the propositional
+solver, so its expansion rules cover atoms, Boolean constants, negation,
+conjunction, disjunction and implication.
+
+## 2. Use a finite many-valued algebra
+
+```julia
+using SoleReasoners
+using SoleLogics: Atom, ∧, →, ⊤
+using SoleLogics.ManyValuedLogics: booleanalgebra, G3, α
+
+p, q = Atom.(["p", "q"])
+alphasat(MVLTLFPTableau, ⊤, ∧(p, q), booleanalgebra)
+alphaval(MVLTLFPTableau, α, →(p, p), G3)
+```
+
+The threshold must belong to the chosen algebra. In the Boolean algebra, use
+`⊤` (not the `α` truth value from `G3`).
+
+## 3. Run all supported tableau families
+
+```julia
+for tableau in (MVLTLFPTableau, MVCLTableau, MVHSTableau, MVLRCC8Tableau)
+    @show tableau alphasat(tableau, ⊤, ∧(p, q), booleanalgebra)
+end
+```
+
+The tableau type determines the temporal, compass, interval, or RCC8 frame
+construction; the decision-procedure call remains the same.
+
+## 4. Add a temporal/modal operator and a timeout
+
+```julia
+using SoleLogics: box, LTLFP_F
+future_p = box(LTLFP_F)(p)
+alphasat(MVLTLFPTableau, ⊤, future_p, booleanalgebra; timeout=10)
+```
+
+`timeout` is important when exploring formulas whose finite-frame search may
+be expensive. A result of `nothing` means the search was interrupted, not that
+the formula failed.
+
+## 5. Select a deterministic expansion policy
+
+```julia
+alphasat(MVLTLFPTableau, ⊤, ∧(p, q), booleanalgebra,
+         roundrobin!, distancefromroot; timeout=10)
+```
+
+`roundrobin!` prevents starvation while `distancefromroot` prefers shallow
+nodes. `inversedistancefromroot` prefers deep nodes; `randombranch` supplies
+random priorities. `mostvoted!` is available when a voting policy is desired.
+
+## 6. Convert input formats
+
+```julia
+using SoleLogics: parseformula
+sat(parseformula("(p ∨ q) ∧ ¬p"))
+# sat(dimacstosole("problem.cnf"))
+```
+
+`dimacstosole` takes a path to a DIMACS CNF file. The utility currently parses
+DIMACS into a SoleLogics formula; it does not write DIMACS files.
+
+## What the results mean
+
+- `sat` returns `Bool`.
+- `alphasat` returns `true`/`false` for a completed search and `nothing` for a
+  timeout or memory-guard abort.
+- `alphaval` returns the corresponding validity result and propagates
+  `nothing` when its search is interrupted.
+
+The source does not state a general decidable fragment or a universal
+termination/completeness guarantee for the modal tableau families. Use the
+finite algebra and `timeout` deliberately, and treat `nothing` as unknown.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -6,13 +6,141 @@ CurrentModule = SoleReasoners
 Pages = ["getting-started.md"]
 ```
 
-# [Getting started](@id man-core)
+# Getting started
 
-*SoleReasoners* mainly provides two tools for reasoning: *alphasat*, which aims at solving the $\alpha$-satisfiability problem, a relaxation of the [boolean satisfiability problem](https://en.wikipedia.org/wiki/Boolean_satisfiability_problem) for many-valued logic asking if an interpretation satisfies a formula with value at least $alpha$, and *alphaval*, which serves as an [automated theorem prover](https://en.wikipedia.org/wiki/Automated_theorem_proving) solving the $\alpha$-validity problem, a relaxation of the validity problem for many-valued logic asking if a formula is satisfied by any interpretation with value at least $\alpha$. Both algorithms are based on the [method of analytic tableaux](https://en.wikipedia.org/wiki/Method_of_analytic_tableaux).
+SoleReasoners provides two decision procedures based on analytic tableaux:
+`alphasat` checks α-satisfiability and `alphaval` checks α-validity. The
+classical propositional procedure is `sat`. Formulas, atoms, truth values and
+finite algebras are provided by SoleLogics.
 
-*SoleReasoners* also provides a suite for managing the tableau expansion policy, allowing for different configurations based on the specific application problem. This system is based on min-heaps concurring to provide candidates for the extraction based on user specified policies, and an agreement function to choose amongst such proposals.
+## Install and make a formula
 
-## SAT solver
+```julia
+using Pkg
+Pkg.add("SoleReasoners")
+
+using SoleReasoners
+using SoleLogics: Atom, ∧, ∨, →, ¬, ⊤
+using SoleLogics.ManyValuedLogics: booleanalgebra
+
+p, q = Atom.(["p", "q"])
+φ = ∧(p, ¬q)
+```
+
+## Propositional SAT
+
+`sat(φ)` returns `true` when the propositional formula has an open tableau
+branch and `false` when every branch closes. The optional policy and metrics
+make branch selection explicit:
+
+```julia
+sat(φ)
+sat(∨(p, q), roundrobin!, distancefromroot)
+```
+
+For text input, use `SoleLogics.parseformula`; for a DIMACS CNF path, use
+`dimacstosole`:
+
+```julia
+using SoleLogics: parseformula
+sat(parseformula("(p ∨ q) ∧ ¬p"))
+# sat(dimacstosole("problem.cnf"))
+```
+
+## α-satisfiability and α-validity
+
+The short form constructs the initial tableau, metric heap and default policy:
+
+```julia
+alphasat(MVLTLFPTableau, ⊤, φ, booleanalgebra)
+alphaval(MVLTLFPTableau, ⊤, →(p, p), booleanalgebra)
+```
+
+`α` is a truth value from the selected finite algebra, not necessarily a Julia
+`Float64`. For a non-Boolean algebra, import its truth values and pass the
+matching algebra, for example `alphaval(MVLTLFPTableau, α, →(p,p), G3)`.
+
+All four exported tableau types can be passed to the same entry points:
+
+```julia
+for tableau in (MVLTLFPTableau, MVCLTableau, MVHSTableau, MVLRCC8Tableau)
+    @show tableau alphasat(tableau, ⊤, ∧(p, q), booleanalgebra)
+end
+```
+
+To bound finite-frame generation and expansion, pass `timeout` in seconds:
+
+```julia
+result = alphasat(MVLTLFPTableau, ⊤, φ, booleanalgebra; timeout=10)
+```
+
+A completed search returns `Bool`. `nothing` means that the timeout or the
+implementation's memory guard stopped the search; it is not a negative answer.
+
+## Supported tableau families
+
+- `MVLTLFPTableau`: many-valued linear temporal logic with future and past.
+- `MVCLTableau`: many-valued compass logic.
+- `MVHSTableau`: many-valued Halpern--Shoham interval logic.
+- `MVLRCC8Tableau`: many-valued Lutz--Wolter RCC8 rectangular logic.
+
+Temporal, modal and relational operators are constructed in SoleLogics. For
+example:
+
+```julia
+using SoleLogics: box, LTLFP_F
+alphasat(MVLTLFPTableau, ⊤, box(LTLFP_F)(p), booleanalgebra; timeout=10)
+```
+
+## Running the playground
+
+From a checkout, run the verified end-to-end script:
+
+```sh
+julia --project=. examples/playground.jl
+```
+
+The script exercises propositional SAT, all four tableau families, a
+non-Boolean algebra, validity, a custom branch policy, and a temporal operator.
+
+## [Known limitations](@id limitations)
+
+The propositional `sat` implementation is separate from the many-valued
+procedures. The latter enumerate and extend finite frames for the supported
+tableau families, but the source does not state a general decidable fragment or
+a universal termination/completeness guarantee. Use `timeout` when exploring.
+A completed call returns `Bool`; `nothing` means timeout or the implementation's
+memory guard stopped the search, not unsatisfiability or invalidity. No model,
+proof, or certificate object is promised by the current return values.
+
+## Exported API at a glance
+
+`SoleReasoners` explicitly exports:
+
+- `sat`, `alphasat`, `alphaval`: decision procedures;
+- `MVLTLFPTableau`, `MVCLTableau`, `MVHSTableau`, `MVLRCC8Tableau`: tableau
+  constructors/types;
+- `roundrobin!`, `mostvoted!`: branch-selection policies;
+- `randombranch`, `distancefromroot`, `inversedistancefromroot`, `formulaheight`:
+  metrics;
+- `booleantofuzzy`, `dimacstosole`: formula/file utilities.
+
+Names such as `Atom`, `∧`, `box`, `booleanalgebra`, `G3`, and `α` belong to
+SoleLogics and are imported separately. See [Examples](@ref examples) for a
+runnable matrix of calls and [Known limitations](@ref limitations) before
+using the procedures in production.
+
+## SAT solver API
+
+```@docs
+sat(
+    formula::Formula,
+    choosenode::F,
+    metrics::Function...
+) where {F<:Function}
+```
+
+## Many-valued APIs
 
 ```@docs
 alphasat(
@@ -21,26 +149,15 @@ alphasat(
     φ::Formula,
     algebra::FiniteFLewAlgebra,
     choosenode::Function,
-    metrics::Function...;
-    kwargs...
-) where {
-    T<:ManyValuedMultiModalTableau,
-    T1<:Truth
-}
-```
+    metrics::Function...
+) where {T<:ManyValuedMultiModalTableau, T1<:Truth}
 
-## Automated theorem prover
-```@docs
 alphaval(
     ::T,
     α::T1,
     φ::Formula,
     algebra::FiniteFLewAlgebra,
     choosenode::Function,
-    metrics::Function...;
-    kwargs...
-) where {
-    T<:ManyValuedMultiModalTableau,
-    T1<:Truth
-}
+    metrics::Function...
+) where {T<:ManyValuedMultiModalTableau, T1<:Truth}
 ```

--- a/examples/playground.jl
+++ b/examples/playground.jl
@@ -1,0 +1,23 @@
+using SoleReasoners
+using SoleLogics: Atom, ∧, ∨, →, ¬, ⊤, box, LTLFP_F
+using SoleLogics.ManyValuedLogics: booleanalgebra, G3, α
+
+p, q = Atom.(["p", "q"])
+
+# Classical propositional tableau.
+@assert sat(∧(p, ¬p)) == false
+@assert sat(∨(p, q), roundrobin!, distancefromroot) == true
+
+# The same many-valued formula through all four supported tableau families.
+for tableau in (MVLTLFPTableau, MVCLTableau, MVHSTableau, MVLRCC8Tableau)
+    @assert alphasat(tableau, ⊤, ∧(p, q), booleanalgebra) == true
+end
+
+# A non-Boolean finite algebra and validity.
+@assert alphaval(MVLTLFPTableau, α, →(p, p), G3) == true
+
+# A temporal operator supplied by SoleLogics; timeout bounds frame search.
+@assert alphasat(MVLTLFPTableau, ⊤, box(LTLFP_F)(p), booleanalgebra;
+                  timeout=10) == true
+
+println("SoleReasoners playground completed")


### PR DESCRIPTION
## Summary

- Adds a newcomer-oriented README path for propositional SAT and α-reasoning.
- Documents the explicit `SoleReasoners` export list, policies, metrics, result meanings, and known limitations.
- Adds a runnable `examples/playground.jl` covering all four tableau families, Boolean and G3 semantics, validity, policy selection, and a temporal operator.
- Publishes the existing Examples page and fixes `$alpha$` to `\alpha` in the getting-started source.

Closes #11.

## Verification

- `julia --project=. examples/playground.jl` (passes).
- `julia --project=. -e 'using Pkg; Pkg.test()'` before and after the documentation changes (both pass; 28,711,137 tests).
- Documenter `makedocs` doctest/cross-reference pass completed with the docs environment; the repository's existing untracked-docstring and inventory warnings remain.

This is documentation for the current default branch only. PR #15's `alphasat` outcome clarification and PR #16's certificate API are not assumed or documented here; this PR should be sequenced after those only if the final merged behavior requires cross-links. The result/`nothing` wording here is limited to behavior present in this branch.
